### PR TITLE
[IMP] product schema: set "PrintImageURL" as mandatory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Please validate every XML file with XSD before providing the feed to us.
 Product Data
 ============
 
-:Version: 1.6
+:Version: 1.7
 
 **Default Schema and Example**
 
@@ -40,6 +40,14 @@ Change log
    :widths: 25 25 50 25
    :header-rows: 1
 
+   * - Version
+     - Date
+     - Comments
+     - Authors
+   * - 1.7
+     - 2026-04-09
+     - Set "PrintImageURL" as mandatory to guarantee that subvariants have images.
+     - Ugnė Sinkevičienė
    * - Version
      - Date
      - Comments

--- a/xml_feeds_schema/schema/Product.xsd
+++ b/xml_feeds_schema/schema/Product.xsd
@@ -176,7 +176,7 @@
                         <xs:element name="WidthMM" type="xs:positiveInteger" minOccurs="0"/>
                         <xs:element name="HeightMM" type="xs:positiveInteger" minOccurs="0"/>
                         <xs:element name="DiameterMM" type="xs:positiveInteger" minOccurs="0"/>
-                        <xs:element name="PrintImageURL" type="T_NotNullString" minOccurs="0">
+                        <xs:element name="PrintImageURL" type="T_NotNullString" minOccurs="1"/>
                           <xs:annotation>
                             <xs:documentation>
                               URL to a picture that displays imprint area for this position.

--- a/xml_feeds_schema/schema/ProductDecoTypesWithoutUnique.xsd
+++ b/xml_feeds_schema/schema/ProductDecoTypesWithoutUnique.xsd
@@ -176,7 +176,7 @@
                         <xs:element name="WidthMM" type="xs:positiveInteger" minOccurs="0"/>
                         <xs:element name="HeightMM" type="xs:positiveInteger" minOccurs="0"/>
                         <xs:element name="DiameterMM" type="xs:positiveInteger" minOccurs="0"/>
-                        <xs:element name="PrintImageURL" type="T_NotNullString" minOccurs="0">
+                        <xs:element name="PrintImageURL" type="T_NotNullString" minOccurs="1">
                           <xs:annotation>
                             <xs:documentation>
                               URL to a picture that displays imprint area for this position.


### PR DESCRIPTION
[IMP] product schema: set "PrintImageURL" as mandatory to guarantee that subvariants have images

https://hive.versada.eu/projects/allbranded/work_packages/25351